### PR TITLE
Replace request with superagent

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "sinon": "^1.17.0"
   },
   "dependencies": {
-    "request": "^2.63.0"
+    "path": "^0.12.7",
+    "superagent": "^1.4.0",
+    "url": "^0.11.0"
   }
 }

--- a/test/Particle.spec.js
+++ b/test/Particle.spec.js
@@ -340,6 +340,7 @@ describe('ParticleAPI', () => {
 				done();
 			}).catch((err) => {
 				err.code.should.equal(400);
+				err.errorDescription.should.containEql('HTTP error 400 from http://127.0.0.1');
 				done();
 			});
 			server.on('request', (req, res) => {


### PR DESCRIPTION
My primary motivation for the switch to superagent is to be compatible with React Native. The request module brings a lot of stuff that RN does not like (https://github.com/facebook/react-native/issues/3600). Superagent is isomorphic friendly and lighter weight.

Another benefit is this greatly reduces the size of the browser compatible bundle. Using request the bundle size is 1.5 MB unminified. Using superagent reduces the size to 139 KB unminified.