### PR TITLE
Use form when included in request

### DIFF
--- a/src/Particle.js
+++ b/src/Particle.js
@@ -192,7 +192,7 @@ class Particle {
 			if (auth) { req.set(Particle.headers(auth)); }
 			if (query) { req.query(query); }
 			if (form) {
-				if (form.username) { req.type('form'); }
+				req.type('form');
 				req.send(form);
 			}
 			req.end((error, res) => {


### PR DESCRIPTION
If form is only used for login, it breaks other API calls, such as callFunction that pass form data. If a form is not desired in the request, don't pass a form from the calling function and the request type will json, the default type.