### PR TITLE
Ability to configure request timeouts

### DIFF
--- a/src/Defaults.js
+++ b/src/Defaults.js
@@ -2,5 +2,6 @@ export default {
 	baseUrl: 'https://api.particle.io',
 	clientSecret: 'particle-api',
 	clientId: 'particle-api',
+	timeout: 30000,
 	tokenDuration: 7776000, // 90 days
 };

--- a/src/Particle.js
+++ b/src/Particle.js
@@ -442,6 +442,7 @@ class Particle {
 			if (query) {
 				req.query(query);
 			}
+			req.timeout(this.timeout);
 			if (files) {
 				Object.keys(files).forEach(k => {
 					req.attach(k, files[k].data, files[k].path);


### PR DESCRIPTION
This is a patch to address what was mentioned in this issue: https://github.com/spark/particle-api-js/issues/19

I chose the default timeout to be 30 seconds, but let me know if this doesn't work for you guys.

Thanks!
