### PR TITLE
Adding responseTemplate and responseTopic to webhook creation

### DIFF
--- a/src/Particle.js
+++ b/src/Particle.js
@@ -322,14 +322,16 @@ class Particle {
 	 * @param  {Object} [$0.headers]            Additional headers to add to the webhook
 	 * @param  {Object} [$0.json]               JSON data
 	 * @param  {Object} [$0.query]              Query string data
+	 * @param  {Object} [$0.responseTemplate]   Webhook response template
+	 * @param  {Object} [$0.responseTopic]      Webhook response topic
 	 * @param  {Boolean} [$0.rejectUnauthorized] Reject invalid HTTPS certificates
 	 * @param  {Object} [$0.webhookAuth]        HTTP Basic Auth information
 	 * @param  {Object} [$0.form]               Form data
 	 * @param  {String} $0.auth               Access Token
 	 * @return {Promise}
 	 */
-	createWebhook({ deviceId, name, url, requestType, headers, json, query, rejectUnauthorized, webhookAuth, form, auth }) {
-		const data = { event: name, url, requestType, headers, json, query, rejectUnauthorized, auth: webhookAuth, form };
+	createWebhook({ deviceId, name, url, requestType, headers, json, query, responseTemplate, responseTopic, rejectUnauthorized, webhookAuth, form, auth }) {
+		const data = { event: name, url, requestType, headers, json, query, responseTemplate, responseTopic, rejectUnauthorized, auth: webhookAuth, form };
 		if (deviceId === 'mine') {
 			data.mydevices = true;
 		} else {

--- a/test/Particle.spec.js
+++ b/test/Particle.spec.js
@@ -41,6 +41,8 @@ const props = {
 	json: {
 		j: 'd'
 	},
+	responseTopic: 'topic',
+	responseTemplate: 'template',
 	webhookAuth: {
 		username: 'u',
 		password: 'p'
@@ -354,6 +356,8 @@ describe('ParticleAPI', () => {
 					data.event.should.equal(props.name);
 					data.url.should.equal(props.url);
 					data.deviceid.should.equal(props.deviceId);
+					data.responseTemplate.should.equal(props.responseTemplate);
+					data.responseTopic.should.equal(props.responseTopic);
 					data.query.should.equal(props.query);
 					data.form.should.equal(props.form);
 					data.json.should.equal(props.json);


### PR DESCRIPTION
This is a patch to address what has been discussed here: https://github.com/spark/particle-api-js/issues/21

@brycekahle 
