### PR TITLE
Add ability to set baseUrl with PARTICLE_SERVER env variable

### DIFF
--- a/src/Defaults.js
+++ b/src/Defaults.js
@@ -1,5 +1,5 @@
 export default {
-	baseUrl: 'https://api.particle.io/',
+	baseUrl: process.env.PARTICLE_SERVER || 'https://api.particle.io/',
 	clientSecret: 'particle-api',
 	clientId: 'particle-api',
 	tokenDuration: 7776000, // 90 days


### PR DESCRIPTION
This way people using local servers don't have to go mess around with the package each time it's installed.