### PR TITLE
.getEventStream method compatible with new product event stream endpoints

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+	"root": true,
 	"parser": "babel-eslint",
 	"extends": "particle",
 	"env": {

--- a/src/Particle.js
+++ b/src/Particle.js
@@ -281,7 +281,7 @@ class Particle {
 	 * @param  {String} [$0.deviceId] Device ID or Name, or `mine` to indicate only your devices.
 	 * @param  {String} [$0.name]     Event Name
 	 * @param  {String} [$0.org]     Organization Slug
-	 * @param  {String} [$0.product]     Product Slug
+	 * @param  {String} [$0.product]     Product Slug or Product ID
 	 * @param  {String} $0.auth     Access Token
 	 * @return {Promise} If the promise resolves, the resolution value will be an EventStream object that will
 	 * emit 'event' events, as well as the specific named event.
@@ -290,25 +290,25 @@ class Particle {
 		let uri = '/v1/';
 		if (org) {
 			uri += `orgs/${org}/`;
-			if (product) {
-				uri += `products/${product}/`;
-			} else if (deviceId && deviceId.toLowerCase() !== 'mine') {
-				uri += `devices/${deviceId}/`;
-			}
-			uri += 'events';
-		} else {
-			if (!deviceId) {
-				uri += 'events';
-			} else if (deviceId.toLowerCase() === 'mine') {
-				uri += 'devices/events';
-			} else {
-				uri += `devices/${deviceId}/events`;
+		}
+
+		if (product) {
+			uri += `products/${product}/`;
+		}
+
+		if (deviceId) {
+			uri += 'devices/';
+			if (!(deviceId.toLowerCase() === 'mine')) {
+				uri += `${deviceId}/`;
 			}
 		}
+
+		uri += 'events';
 
 		if (name) {
 			uri += `/${encodeURIComponent(name)}`;
 		}
+
 		return new EventStream(`${this.baseUrl}${uri}`, auth, { debug: this.debug }).connect();
 	}
 

--- a/test/Particle.spec.js
+++ b/test/Particle.spec.js
@@ -339,6 +339,27 @@ describe('ParticleAPI', () => {
 					uri.should.endWith('v1/orgs/test-org/products/test-product/events/test');
 				});
 			});
+			it('requests a product\'s event without an org provided', () => {
+				return api.getEventStream({ product: 'test-product'}).then(({ uri }) => {
+					uri.should.endWith('v1/products/test-product/events');
+				});
+			});
+			it('requests a product\'s named event without an org provided', () => {
+				return api.getEventStream({ product: 'test-product', name: 'foo'}).then(({ uri }) => {
+					uri.should.endWith('v1/products/test-product/events/foo');
+				});
+			});
+			it('requests product\'s device events', () => {
+				return api.getEventStream({ product: 'test-product', deviceId: props.deviceId }).then(({ uri }) => {
+					uri.should.endWith(`v1/products/test-product/devices/${props.deviceId}/events`);
+				});
+			});
+			it('requests product\'s device named events', () => {
+				return api.getEventStream({ product: 'test-product', deviceId: props.deviceId, name: 'foo' }).then(({ uri }) => {
+					uri.should.endWith(`v1/products/test-product/devices/${props.deviceId}/events/foo`);
+				});
+			});
+
 		});
 		describe('.publishEvent', () => {
 			it('sends proper data', () => {


### PR DESCRIPTION
Support the following new routes (all have tests):

```
/v1/products/:productIdOrSlug/events
/v1/products/:productIdOrSlug/events/:event_name
/v1/products/:productIdOrSlug/devices/:orgDeviceId/events
/v1/products/:productIdOrSlug/devices/:orgDeviceId/events/:event_name
```