### PR TITLE
Fixed Particle.integration.js test, updated for new downloaded filesize.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babel-register": "^6.5.2",
     "babelify": "^7.3.0",
     "brfs": "^1.4.3",
-    "browserify": "^13.0.0",
+    "browserify": "13.0.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
     "coveralls": "^2.11.4",

--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -143,7 +143,7 @@ class EventStream extends EventEmitter {
 	parseEventStreamLine(pos, fieldLength, lineLength) {
 		if (lineLength === 0) {
 			try {
-				if (this.data.length > 0 && this.eventName) {
+				if (this.data.length > 0 && this.event) {
 					const event = JSON.parse(this.data);
 					event.name = this.eventName || '';
 					if (this.eventName !== 'event') {

--- a/src/EventStream.js
+++ b/src/EventStream.js
@@ -143,7 +143,7 @@ class EventStream extends EventEmitter {
 	parseEventStreamLine(pos, fieldLength, lineLength) {
 		if (lineLength === 0) {
 			try {
-				if (this.data.length > 0 && this.event) {
+				if (this.data.length > 0 && this.eventName) {
 					const event = JSON.parse(this.data);
 					event.name = this.eventName || '';
 					if (this.eventName !== 'event') {

--- a/test/Particle.integration.js
+++ b/test/Particle.integration.js
@@ -6,7 +6,7 @@ describe('Particle', () => {
 		it('download the file', () => {
 			const sut = new Particle();
 			const url = 'https://s3.amazonaws.com/binaries.particle.io/libraries/neopixel/neopixel-0.0.10.tar.gz';
-			const fileSize = 24684;
+			const fileSize = 25505;
 			return sut.downloadFile({ url })
 			.then(contents => {
 				expect(contents.length || contents.byteLength).to.equal(fileSize);


### PR DESCRIPTION
- This is a minor fix to the npm test code that should result in particle-api-js now passing the travis-ci tests.
- The file neopixel-0.0.10.tar.gz changed in size (24684 => 25505) and that is now reflected in the test.