### PR TITLE
Fixed npm test filesize issue, also fixed the npm run test:browser issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "babel-watch": "babel src -d lib --watch --source-maps",
-    "prepublish": "npm run lint && npm run compile",
+    "prepublish": "npm run lint && npm run compile && npm run build",
     "compile": "babel src -sd lib",
     "test": "mocha test/ -R spec --compilers js:babel-register",
     "test:browser": "karma start --single-run",

--- a/test/Particle.integration.js
+++ b/test/Particle.integration.js
@@ -6,7 +6,7 @@ describe('Particle', () => {
 		it('download the file', () => {
 			const sut = new Particle();
 			const url = 'https://s3.amazonaws.com/binaries.particle.io/libraries/neopixel/neopixel-0.0.10.tar.gz';
-			const fileSize = 24684;
+			const fileSize = 25505;
 			return sut.downloadFile({ url })
 			.then(contents => {
 				expect(contents.length || contents.byteLength).to.equal(fileSize);


### PR DESCRIPTION
- Added npm run build to prepublish in package.json to fix the browser build test that was failing.
- Changed the neopixel-0.0.10.tar.gz file size so that test now passes.