### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ bower install particle-api-js
 
 #### jsDelivr CDN
 ```html
-<script type="text/javascript" src="//cdn.jsdelivr.net/particle-api-js/5/particle.min.js">
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/particle-api-js@6/lib/Particle.min.js">
 </script>
 ```
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/particle-api-js.

Feel free to ping me if you have any questions regarding this change.