### PR TITLE
Update to latest superagent with support for nested directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ node_js:
 matrix:
   include:
     # This extra job will run tests in the browser
-    - node_js: 5
+    - node_js: 6
       env: TEST_SUITE=browser
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -75,9 +75,8 @@
   },
   "dependencies": {
     "babel-runtime": "^6.9.2",
-    "form-data": "https://github.com/spark/form-data/archive/v1.0.0-rc4.tar.gz",
     "stream-http": "https://github.com/spark/stream-http/archive/v2.2.1.tar.gz",
-    "superagent": "^2.2.0",
+    "superagent": "^3.6.0",
     "superagent-prefix": "0.0.2"
   },
   "browser": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   "dependencies": {
     "babel-runtime": "^6.9.2",
     "stream-http": "https://github.com/spark/stream-http/archive/v2.2.1.tar.gz",
+    "form-data": ">2.2.0",
     "superagent": "^3.6.0",
     "superagent-prefix": "0.0.2"
   },

--- a/src/Agent.js
+++ b/src/Agent.js
@@ -143,7 +143,7 @@ export default class Agent {
 				let options = {
 					filepath: file.path
 				};
-				if (this._inBrowser()) {
+				if (this._inBrowser(makerequest)) {
 					options = file.path;
 				}
 				req.attach(name, file.data, options);
@@ -162,10 +162,9 @@ export default class Agent {
 		return req;
 	}
 
-	_inBrowser() {
-		const browserWindow = (typeof window !== 'undefined');
-		const webWorker = (typeof self !== 'undefined');
-		return browserWindow || webWorker;
+	_inBrowser(makerequest) {
+		// superagent only has the getXHR method in the browser version
+		return !!makerequest.getXHR;
 	}
 
 	_applyContext(req, context) {

--- a/src/Agent.js
+++ b/src/Agent.js
@@ -19,8 +19,6 @@
 
 import request from 'superagent';
 import prefix from 'superagent-prefix';
-import path from 'path';
-
 
 export default class Agent {
 

--- a/src/Agent.js
+++ b/src/Agent.js
@@ -139,10 +139,14 @@ export default class Agent {
 		}
 		if (files) {
 			for (let [name, file] of Object.entries(files)) {
-				req._getFormData().append(name, file.data, {
-					filename: file.path.replace(/\\/g, '/'),
-					includePath: true
-				});
+				// API for Form Data is different in Node and in browser
+				let options = {
+					filepath: file.path
+				};
+				if (this._inBrowser()) {
+					options = file.path;
+				}
+				req.attach(name, file.data, options);
 			}
 			if (form) {
 				for (let [name, value] of Object.entries(form)) {
@@ -156,6 +160,12 @@ export default class Agent {
 			req.send(data);
 		}
 		return req;
+	}
+
+	_inBrowser() {
+		const browserWindow = (typeof window !== 'undefined');
+		const webWorker = (typeof self !== 'undefined');
+		return browserWindow || webWorker;
 	}
 
 	_applyContext(req, context) {

--- a/src/Particle.js
+++ b/src/Particle.js
@@ -405,7 +405,7 @@ class Particle {
 	 * Compile and flash application firmware to a device. Pass a pre-compiled binary to flash it directly to the device.
 	 * @param  {Object} options Options for this API call
 	 * @param  {String} options.deviceId      Device ID or Name
-	 * @param  {Object} options.files         Object containing files to be compiled and flashed. Keys should be the filenames, and the values should be a path or Buffer of the file contents.
+	 * @param  {Object} options.files         Object containing files to be compiled and flashed. Keys should be the filenames, including relative path, and the values should be a path or Buffer of the file contents in Node, or a File or Blob in the browser.
 	 * @param  {String} [options.targetVersion=latest] System firmware version to compile against
 	 * @param  {String} options.auth          String
 	 * @return {Promise}
@@ -442,7 +442,7 @@ class Particle {
 	/**
 	 * Compile firmware using the Particle Cloud
 	 * @param  {Object} options Options for this API call
-	 * @param  {Object} options.files         Object containing files to be compiled. Keys should be the filenames, and the values should be a path or Buffer of the file contents.
+	 * @param  {Object} options.files         Object containing files to be compiled. Keys should be the filenames, including relative path, and the values should be a path or Buffer of the file contents in Node, or a File or Blob in the browser.
 	 * @param  {Number} [options.platformId]    Platform id number of the device you are compiling for. Common values are 0=Core, 6=Photon, 10=Electron.
 	 * @param  {String} [options.targetVersion=latest] System firmware version to compile against
 	 * @param  {String} options.auth          Access Token
@@ -930,6 +930,7 @@ class Particle {
 	 * Contribute a new library version from a compressed archive
 	 * @param  {Object} options Options for this API call
 	 * @param  {String} options.archive Compressed archive file containing the library sources
+	 *                                  Either a path or Buffer of the file contents in Node, or a File or Blob in the browser.
 	 * @param  {String} options.auth Access Token
 	 * @return {Promise}
 	 */
@@ -974,7 +975,8 @@ class Particle {
 	 */
 	downloadFile({ url }) {
 		let req = request.get(url);
-		if (req.buffer) {
+		// Different API in Node and browser
+		if (!request.getXHR) {
 			req = req.buffer(true).parse(binaryParser);
 		} else if (req.responseType) {
 			req = req.responseType('arraybuffer').then(res => {
@@ -1079,6 +1081,7 @@ class Particle {
 	 * List product firmware versions
 	 * @param  {Object} options Options for this API call
 	 * @param  {Object} options.file    Path or Buffer of the new firmware file
+	 *                                  Either a path or Buffer of the file contents in Node, or a File or Blob in the browser.
 	 * @param  {Number} options.version Version number of new firmware
 	 * @param  {String} options.title   Short identifier for the new firmware
 	 * @param  {String} [options.description] Longer description for the new firmware

--- a/test/Agent.spec.js
+++ b/test/Agent.spec.js
@@ -204,19 +204,15 @@ describe('Agent', () => {
 			sut.prefix = undefined;
 			const req = sinon.stub();
 			const attach = sinon.stub();
-			req.returns({_getFormData: () => {
-				return {
-					append: attach
-				}
-			}});
+			req.returns({ attach: attach });
 			const files = {
 				file: {data: 'filedata', path: 'filepath'},
 				file2: {data: 'file2data', path: 'file2path'}
 			};
 			sut._buildRequest({uri: 'uri', method: 'get', files: files, makerequest: req});
 			expect(attach.callCount).to.be.equal(2);
-			expect(attach).to.be.calledWith('file', 'filedata', {filename: 'filepath', includePath: true});
-			expect(attach).to.be.calledWith('file2', 'file2data', {filename: 'file2path', includePath: true});
+			expect(attach).to.be.calledWith('file', 'filedata', {filepath: 'filepath'});
+			expect(attach).to.be.calledWith('file2', 'file2data', {filepath: 'file2path'});
 		});
 
 		it('should attach files and form data', () => {
@@ -225,11 +221,10 @@ describe('Agent', () => {
 			const req = sinon.stub();
 			const attach = sinon.stub();
 			const field = sinon.stub();
-			req.returns({_getFormData: () => {
-				return {
-					append: attach
-				}
-			}, field: field});
+			req.returns({
+				attach: attach,
+				field: field
+			});
 			const files = {
 				file: {data: 'filedata', path: 'filepath'},
 				file2: {data: 'file2data', path: 'file2path'}
@@ -237,8 +232,8 @@ describe('Agent', () => {
 			const form = {form1: 'value1', form2: 'value2'};
 			sut._buildRequest({uri: 'uri', method: 'get', files: files, form: form, makerequest: req});
 			expect(attach.callCount).to.be.equal(2);
-			expect(attach).to.be.calledWith('file', 'filedata', {filename: 'filepath', includePath: true});
-			expect(attach).to.be.calledWith('file2', 'file2data', {filename: 'file2path', includePath: true});
+			expect(attach).to.be.calledWith('file', 'filedata', {filepath: 'filepath'});
+			expect(attach).to.be.calledWith('file2', 'file2data', {filepath: 'file2path'});
 			expect(field.callCount).to.be.equal(2);
 			expect(field).to.be.calledWith('form1', 'value1');
 			expect(field).to.be.calledWith('form2', 'value2');

--- a/travis_tests.sh
+++ b/travis_tests.sh
@@ -7,6 +7,7 @@ if [ "${TEST_SUITE}" = "browser" ]; then
   sh -e /etc/init.d/xvfb start
   # give xvfb some time to start
   sleep 3 
+  npm run build
   npm run test:browser
 else
   npm run test


### PR DESCRIPTION
So I have an alternative to trying to patch the form-data package used in superagent (#71). Let's just upgrade superagent to the latest version with support for passing the filename.

The advantage are:
1) No separate fork of form-data
2) form-data handles path normalization
3) superagent reads files in node (fixes #45)

Manual integration test in browser:
```
rm -rf node_modules
npm install
npm run compile && npm run build
```
Open this file in browser
```
<html>
  <head>
    <script src="dist/particle.min.js"></script>
    <script>
var particle = new Particle();
var TOK = 'your_token';
var promise = particle.flashDevice({ deviceId: 'your_device', files: {
  'application.ino': new Blob(['#include "subdir/status.h"\nextern int foobar; void setup() { Particle.variable("foobar", foobar); }'], { type: "text/plain" }),
  'subdir/status.h': new Blob(['int foobar;'], { type: "text/plain" }),
}, auth: TOK
});

promise.then(function(response) {
  console.log(JSON.stringify(response.body));
}).catch(function(err) {
  console.error(JSON.stringify(err));
});
    </script>
  </head>
</html>
```

